### PR TITLE
fix: CI workflow job names and commands for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +18,7 @@ jobs:
           sudo apt-get install -y git
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           
@@ -32,7 +31,7 @@ jobs:
           
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -43,10 +42,9 @@ jobs:
         
       - name: Run linting
         run: |
-          poetry run make lint
+          make lint
           
   test:
-    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +55,7 @@ jobs:
           sudo apt-get install -y git
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           
@@ -70,7 +68,7 @@ jobs:
           
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -83,10 +81,9 @@ jobs:
         env:
           PYTHONPATH: src
         run: |
-          poetry run pytest tests/ -v --tb=short
+          make test
           
   security:
-    name: Security
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +94,7 @@ jobs:
           sudo apt-get install -y git
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           
@@ -110,7 +107,7 @@ jobs:
           
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,11 @@
 name: Lint
 
 on:
-  push:
-    branches: [ master, main ]
   pull_request:
     branches: [ master, main ]
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +27,7 @@ jobs:
           sudo apt-get install -y git
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           
@@ -43,7 +40,7 @@ jobs:
           
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -54,4 +51,4 @@ jobs:
         
       - name: Run linting
         run: |
-          poetry run make lint 
+          make lint 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # ──────────────────────────────────────────────────────────────────────────
 # Project variables
 PROJECT_NAME      = mcp-pr-recommender
-PACKAGE_NAME      = pr_recommender
+PACKAGE_NAME      = mcp_pr_recommender
 DOCS_DIR          = docs
 HANDSDOWN_PARAMS  = -o $(DOCS_DIR)/ -n $(PACKAGE_NAME) --name "MCP PR Recommender" --cleanup
 


### PR DESCRIPTION
- Remove job 'name' fields to fix branch protection check naming (lint, test, security)
- Remove duplicate workflow triggers (lint.yml now pull_request only)
- Fix Makefile PACKAGE_NAME to match actual directory structure
- Update GitHub Actions to latest versions (setup-python@v5, cache@v4, upload-artifact@v4)
- Fix CI commands: 'poetry run make' -> 'make', 'test-fast' -> 'test'

🤖 Generated with [Claude Code](https://claude.ai/code)